### PR TITLE
Add support for additional type conversions

### DIFF
--- a/src/type-converter.js
+++ b/src/type-converter.js
@@ -1,6 +1,5 @@
 const { ensure, unimplemented } = require("./utils");
-const { newSlice, extractSlice, getSliceData, getStr,
-  POINTER_WIDTH, newF32Slice, getF32SliceData } = require("./wasm-io");
+const { newF32Slice, newSlice, extractSlice, getStr, POINTER_WIDTH } = require("./wasm-io");
 const { TextDecoder, TextEncoder } = require("text-encoding");
 
 /**
@@ -40,7 +39,7 @@ const typeConversions = {
       const { memory } = exports;
       ensure(memory, "You need to export the main memory to pass strings to WASM");
       const [ptr, len] = extractSlice(memory, data);
-      return getSliceData(memory, ptr, len);
+      return new Uint8Array(memory.buffer, ptr, len);
     },
     /**
      * Allocate memory for mutable return parameters; used before calling Rust
@@ -238,7 +237,7 @@ const typeConversions = {
       ensure(memory, "You need to export the main memory to pass strings to WASM");
       // Actually, just read it like a slice, we copy it anyway, so the capacity doesn't matter
       const [ptr, len] = extractSlice(memory, data);
-      return getF32SliceData(memory, ptr, len);
+      return new Float32Array(memory.buffer, ptr, len);
     },
     /**
      * @param {Array<any>} args
@@ -282,7 +281,7 @@ const typeConversions = {
       ensure(memory, "You need to export the main memory to pass strings to WASM");
       // Actually, just read it like a slice, we copy it anyway, so the capacity doesn't matter
       const [ptr, len] = extractSlice(memory, data);
-      return getSliceData(memory, ptr, len);
+      return new Uint8Array(memory.buffer, ptr, len);
     },
     /**
      * @param {Array<any>} args

--- a/src/type-converter.js
+++ b/src/type-converter.js
@@ -1,5 +1,10 @@
 const { ensure, unimplemented } = require("./utils");
-const { newF32Slice, newSlice, newU16Slice, newU32Slice, extractSlice, extractVectorSlice, getStr, POINTER_WIDTH } = require("./wasm-io");
+const {
+  newF32Slice, newSlice, newU16Slice, newU32Slice,
+  extractSlice, extractVectorSlice,
+  getStr,
+  POINTER_WIDTH,
+} = require("./wasm-io");
 const { TextDecoder, TextEncoder } = require("text-encoding");
 
 /**
@@ -255,50 +260,6 @@ const typeConversions = {
       return ptr;
     },
   },
-  "Vec<u32>": {
-    /**
-     * @param {Uint32Array} data
-     * @param {WebAssembly.Module} exports
-     */
-    arg(data, exports) {
-      ensure(data instanceof Uint32Array, "Can only use `Uint32Array` as `&[u32]`");
-
-      // @ts-ignore -- yes accessing these exports works
-      const { alloc, memory } = exports;
-      ensure(alloc, "You need to export an `alloc` function to get strings from WASM");
-      ensure(memory, "You need to export the main memory to get strings from WASM");
-
-      return newU32Slice(memory, alloc, data);
-    },
-    /**
-     * @param {Pointer} data
-     * @param {WebAssembly.Module} exports
-     * @return {Uint16Array}
-     */
-    ret(data, exports) {
-      // @ts-ignore -- yes accessing these exports works
-      const { memory } = exports;
-      ensure(memory, "You need to export the main memory to pass strings to WASM");
-      // Actually, just read it like a slice, we copy it anyway, so the capacity doesn't matter
-      const [ptr, len] = extractVectorSlice(memory, data);
-      return new Uint32Array(memory.buffer, ptr, len);
-    },
-    /**
-     * @param {Array<any>} args
-     * @param {WebAssembly.Module} exports
-     * @return {Pointer}
-     */
-    outParam(args, exports) {
-      // @ts-ignore -- yes accessing these exports works
-      const { alloc, memory } = exports;
-      ensure(alloc, "You need to export an `alloc` function to get strings from WASM");
-      ensure(memory, "You need to export the main memory to get strings from WASM");
-
-      const ptr = alloc(3 * POINTER_WIDTH);
-      args.unshift(ptr);
-      return ptr;
-    },
-  },
   "Vec<u16>": {
     /**
      * @param {Uint16Array} data
@@ -326,6 +287,50 @@ const typeConversions = {
       // Actually, just read it like a slice, we copy it anyway, so the capacity doesn't matter
       const [ptr, len] = extractVectorSlice(memory, data);
       return new Uint16Array(memory.buffer, ptr, len);
+    },
+    /**
+     * @param {Array<any>} args
+     * @param {WebAssembly.Module} exports
+     * @return {Pointer}
+     */
+    outParam(args, exports) {
+      // @ts-ignore -- yes accessing these exports works
+      const { alloc, memory } = exports;
+      ensure(alloc, "You need to export an `alloc` function to get strings from WASM");
+      ensure(memory, "You need to export the main memory to get strings from WASM");
+
+      const ptr = alloc(3 * POINTER_WIDTH);
+      args.unshift(ptr);
+      return ptr;
+    },
+  },
+  "Vec<u32>": {
+    /**
+     * @param {Uint32Array} data
+     * @param {WebAssembly.Module} exports
+     */
+    arg(data, exports) {
+      ensure(data instanceof Uint32Array, "Can only use `Uint32Array` as `&[u32]`");
+
+      // @ts-ignore -- yes accessing these exports works
+      const { alloc, memory } = exports;
+      ensure(alloc, "You need to export an `alloc` function to get strings from WASM");
+      ensure(memory, "You need to export the main memory to get strings from WASM");
+
+      return newU32Slice(memory, alloc, data);
+    },
+    /**
+     * @param {Pointer} data
+     * @param {WebAssembly.Module} exports
+     * @return {Uint32Array}
+     */
+    ret(data, exports) {
+      // @ts-ignore -- yes accessing these exports works
+      const { memory } = exports;
+      ensure(memory, "You need to export the main memory to pass strings to WASM");
+      // Actually, just read it like a slice, we copy it anyway, so the capacity doesn't matter
+      const [ptr, len] = extractVectorSlice(memory, data);
+      return new Uint32Array(memory.buffer, ptr, len);
     },
     /**
      * @param {Array<any>} args

--- a/src/type-converter.js
+++ b/src/type-converter.js
@@ -1,5 +1,6 @@
 const { ensure, unimplemented } = require("./utils");
-const { newSlice, extractSlice, getSliceData, getStr, POINTER_WIDTH } = require("./wasm-io");
+const { newSlice, extractSlice, getSliceData, getStr,
+  POINTER_WIDTH, newF32Slice, getF32SliceData } = require("./wasm-io");
 const { TextDecoder, TextEncoder } = require("text-encoding");
 
 /**
@@ -12,6 +13,8 @@ const { TextDecoder, TextEncoder } = require("text-encoding");
 const typeConversions = {
   "&[u8]": {
     /**
+     * Copy &[u8] arguments into shared memory before passing to Rust
+     *
      * @param {Uint8Array} data
      * @param {WebAssembly.Module} exports
      */
@@ -26,6 +29,8 @@ const typeConversions = {
       return newSlice(memory, alloc, data);
     },
     /**
+     * Copy &[u8] return values from shared memory on return from Rust
+     *
      * @param {Pointer} data
      * @param {WebAssembly.Module} exports
      * @return {Uint8Array}
@@ -38,6 +43,8 @@ const typeConversions = {
       return getSliceData(memory, ptr, len);
     },
     /**
+     * Allocate memory for mutable return parameters; used before calling Rust
+     *
      * @param {Array<any>} args
      * @param {WebAssembly.Module} exports
      * @return {Pointer}
@@ -188,6 +195,50 @@ const typeConversions = {
       // Actually, just read it like a slice, we copy it anyway, so the capacity doesn't matter
       const [ptr, len] = extractSlice(memory, data);
       return getStr(memory, ptr, len);
+    },
+    /**
+     * @param {Array<any>} args
+     * @param {WebAssembly.Module} exports
+     * @return {Pointer}
+     */
+    outParam(args, exports) {
+      // @ts-ignore -- yes accessing these exports works
+      const { alloc, memory } = exports;
+      ensure(alloc, "You need to export an `alloc` function to get strings from WASM");
+      ensure(memory, "You need to export the main memory to get strings from WASM");
+
+      const ptr = alloc(3 * POINTER_WIDTH);
+      args.unshift(ptr);
+      return ptr;
+    },
+  },
+  "Vec<f32>": {
+    /**
+     * @param {Float32Array} data
+     * @param {WebAssembly.Module} exports
+     */
+    arg(data, exports) {
+      ensure(data instanceof Float32Array, "Can only use `Float32Array` as `Vec<f32>`");
+
+      // @ts-ignore -- yes accessing these exports works
+      const { alloc, memory } = exports;
+      ensure(alloc, "You need to export an `alloc` function to get strings from WASM");
+      ensure(memory, "You need to export the main memory to get strings from WASM");
+
+      return newF32Slice(memory, alloc, data);
+    },
+    /**
+     * @param {Pointer} data
+     * @param {WebAssembly.Module} exports
+     * @return {Float32Array}
+     */
+    ret(data, exports) {
+      // @ts-ignore -- yes accessing these exports works
+      const { memory } = exports;
+      ensure(memory, "You need to export the main memory to pass strings to WASM");
+      // Actually, just read it like a slice, we copy it anyway, so the capacity doesn't matter
+      const [ptr, len] = extractSlice(memory, data);
+      return getF32SliceData(memory, ptr, len);
     },
     /**
      * @param {Array<any>} args

--- a/src/type-converter.js
+++ b/src/type-converter.js
@@ -1,5 +1,5 @@
 const { ensure, unimplemented } = require("./utils");
-const { newF32Slice, newSlice, extractSlice, getStr, POINTER_WIDTH } = require("./wasm-io");
+const { newF32Slice, newSlice, newU16Slice, extractSlice, getStr, POINTER_WIDTH } = require("./wasm-io");
 const { TextDecoder, TextEncoder } = require("text-encoding");
 
 /**
@@ -268,12 +268,12 @@ const typeConversions = {
       ensure(alloc, "You need to export an `alloc` function to get strings from WASM");
       ensure(memory, "You need to export the main memory to get strings from WASM");
 
-      return newSlice(memory, alloc, data);
+      return newU16Slice(memory, alloc, data);
     },
     /**
      * @param {Pointer} data
      * @param {WebAssembly.Module} exports
-     * @return {Uint8Array}
+     * @return {Uint16Array}
      */
     ret(data, exports) {
       // @ts-ignore -- yes accessing these exports works

--- a/src/type-converter.js
+++ b/src/type-converter.js
@@ -255,6 +255,50 @@ const typeConversions = {
       return ptr;
     },
   },
+  "Vec<u16>": {
+    /**
+     * @param {Uint16Array} data
+     * @param {WebAssembly.Module} exports
+     */
+    arg(data, exports) {
+      ensure(data instanceof Uint16Array, "Can only use `Uint16Array` as `&[u16]`");
+
+      // @ts-ignore -- yes accessing these exports works
+      const { alloc, memory } = exports;
+      ensure(alloc, "You need to export an `alloc` function to get strings from WASM");
+      ensure(memory, "You need to export the main memory to get strings from WASM");
+
+      return newSlice(memory, alloc, data);
+    },
+    /**
+     * @param {Pointer} data
+     * @param {WebAssembly.Module} exports
+     * @return {Uint8Array}
+     */
+    ret(data, exports) {
+      // @ts-ignore -- yes accessing these exports works
+      const { memory } = exports;
+      ensure(memory, "You need to export the main memory to pass strings to WASM");
+      // Actually, just read it like a slice, we copy it anyway, so the capacity doesn't matter
+      const [ptr, len] = extractSlice(memory, data);
+      return new Uint16Array(memory.buffer, ptr, len);
+    },
+    /**
+     * @param {Array<any>} args
+     * @param {WebAssembly.Module} exports
+     * @return {Pointer}
+     */
+    outParam(args, exports) {
+      // @ts-ignore -- yes accessing these exports works
+      const { alloc, memory } = exports;
+      ensure(alloc, "You need to export an `alloc` function to get strings from WASM");
+      ensure(memory, "You need to export the main memory to get strings from WASM");
+
+      const ptr = alloc(3 * POINTER_WIDTH);
+      args.unshift(ptr);
+      return ptr;
+    },
+  },
   "Vec<u8>": {
     /**
      * @param {Uint8Array} data

--- a/src/type-converter.js
+++ b/src/type-converter.js
@@ -1,5 +1,5 @@
 const { ensure, unimplemented } = require("./utils");
-const { newF32Slice, newSlice, newU16Slice, extractSlice, getStr, POINTER_WIDTH } = require("./wasm-io");
+const { newF32Slice, newSlice, newU16Slice, extractSlice, extractVectorSlice, getStr, POINTER_WIDTH } = require("./wasm-io");
 const { TextDecoder, TextEncoder } = require("text-encoding");
 
 /**
@@ -236,7 +236,7 @@ const typeConversions = {
       const { memory } = exports;
       ensure(memory, "You need to export the main memory to pass strings to WASM");
       // Actually, just read it like a slice, we copy it anyway, so the capacity doesn't matter
-      const [ptr, len] = extractSlice(memory, data);
+      const [ptr, len] = extractVectorSlice(memory, data);
       return new Float32Array(memory.buffer, ptr, len);
     },
     /**
@@ -280,7 +280,7 @@ const typeConversions = {
       const { memory } = exports;
       ensure(memory, "You need to export the main memory to pass strings to WASM");
       // Actually, just read it like a slice, we copy it anyway, so the capacity doesn't matter
-      const [ptr, len] = extractSlice(memory, data);
+      const [ptr, len] = extractVectorSlice(memory, data);
       return new Uint16Array(memory.buffer, ptr, len);
     },
     /**
@@ -324,7 +324,7 @@ const typeConversions = {
       const { memory } = exports;
       ensure(memory, "You need to export the main memory to pass strings to WASM");
       // Actually, just read it like a slice, we copy it anyway, so the capacity doesn't matter
-      const [ptr, len] = extractSlice(memory, data);
+      const [ptr, len] = extractVectorSlice(memory, data);
       return new Uint8Array(memory.buffer, ptr, len);
     },
     /**

--- a/src/wasm-io.js
+++ b/src/wasm-io.js
@@ -117,6 +117,30 @@ function newF32Slice(memory, alloc, data) {
 }
 
 /**
+ * Create a slice of `[ptr, len]` from data (by allocating a buffer)
+ *
+ * @param {WebAssembly.Memory} memory
+ * @param {Float32Array} data
+ * @param {(length: number) => Pointer} alloc
+ * @returns {Pointer} Pointer to `[Pointer, number]` pair
+ */
+function newU16Slice(memory, alloc, data) {
+  const len = data.length;
+  const sliceData = alloc(len * 2);
+  const memView = new Uint16Array(memory.buffer);
+
+  for (let i = 0; i < len; i++) {
+    memView[sliceData + i] = data[i];
+  }
+
+  const ptr = alloc(2 * POINTER_WIDTH);
+  writeI32(memory, ptr, sliceData);
+  writeI32(memory, ptr + POINTER_WIDTH, len);
+
+  return ptr;
+}
+
+/**
  * Get Rust String
  *
  * @param {WebAssembly.Memory} memory

--- a/src/wasm-io.js
+++ b/src/wasm-io.js
@@ -89,19 +89,7 @@ function newSlice(memory, alloc, data) {
  * @return {Uint8Array}
  */
 function getSliceData(memory, pointer, length) {
-  /**
-   * @param {Pointer} ptr
-   * @param {number} len
-   */
-  const getData = function*(ptr, len) {
-    const memView = new Uint8Array(memory.buffer);
-    for (let index = 0; index < len; index++) {
-      if (memView[ptr] === undefined) { throw new Error(`Tried to read undef mem at ${ptr}`); }
-      yield memView[ptr + index];
-    }
-  };
-
-  return new Uint8Array(getData(pointer, length));
+  return new Uint8Array(memory.buffer, pointer, length);
 }
 
 /**
@@ -129,30 +117,6 @@ function newF32Slice(memory, alloc, data) {
 }
 
 /**
- * @param {WebAssembly.Memory} memory
- * @param {Pointer} pointer
- * @param {number} length
- * @return {Float32Array}
- */
-function getF32SliceData(memory, pointer, length) {
-  /**
-   * @param {Pointer} ptr
-   * @param {number} len
-   */
-  const getData = function*(ptr, len) {
-    const memView = new Float32Array(memory.buffer, pointer);
-    for (let index = 0; index < len; index++) {
-      if (memView[index] === undefined) {
-        throw new Error(`Tried to read undef mem at ${ptr}`);
-      }
-      yield memView[index];
-    }
-  };
-
-  return new Float32Array(getData(pointer, length));
-}
-
-/**
  * Get Rust String
  *
  * @param {WebAssembly.Memory} memory
@@ -170,8 +134,6 @@ function getStr(memory, pointer, length) {
 module.exports = {
   POINTER_WIDTH,
   extractSlice,
-  getF32SliceData,
-  getSliceData,
   getStr,
   newF32Slice,
   newSlice,

--- a/src/wasm-io.js
+++ b/src/wasm-io.js
@@ -169,6 +169,31 @@ function newU16Slice(memory, alloc, data) {
   return ptr;
 }
 
+
+/**
+ * Create a slice of `[ptr, len]` from data (by allocating a buffer)
+ *
+ * @param {WebAssembly.Memory} memory
+ * @param {Float32Array} data
+ * @param {(length: number) => Pointer} alloc
+ * @returns {Pointer} Pointer to `[Pointer, number]` pair
+ */
+function newU32Slice(memory, alloc, data) {
+  const len = data.length;
+  const sliceData = alloc(len * 4);
+  const memView = new Uint32Array(memory.buffer);
+
+  for (let i = 0; i < len; i++) {
+    memView[sliceData + i] = data[i];
+  }
+
+  const ptr = alloc(2 * POINTER_WIDTH);
+  writeI32(memory, ptr, sliceData);
+  writeI32(memory, ptr + POINTER_WIDTH, len);
+
+  return ptr;
+}
+
 /**
  * Get Rust String
  *
@@ -191,4 +216,5 @@ module.exports = {
   getStr,
   newF32Slice,
   newSlice,
+  newU32Slice,
 };

--- a/src/wasm-io.js
+++ b/src/wasm-io.js
@@ -169,12 +169,11 @@ function newU16Slice(memory, alloc, data) {
   return ptr;
 }
 
-
 /**
  * Create a slice of `[ptr, len]` from data (by allocating a buffer)
  *
  * @param {WebAssembly.Memory} memory
- * @param {Float32Array} data
+ * @param {Uint32Array} data
  * @param {(length: number) => Pointer} alloc
  * @returns {Pointer} Pointer to `[Pointer, number]` pair
  */

--- a/src/wasm-io.js
+++ b/src/wasm-io.js
@@ -59,6 +59,35 @@ function extractSlice(memory, inPointer) {
 }
 
 /**
+ * Retrieve `[ptr, len]` from position `offset` in `memory`
+ *
+ * @param {WebAssembly.Memory} memory
+ * @param {Pointer} inPointer
+ * @returns {[Pointer, number]}
+ */
+function extractVectorSlice(memory, inPointer) {
+  /**
+   * @param {Uint8Array} bytes
+   */
+  const iterToI32 = (bytes) => {
+    const view = new DataView(bytes.buffer);
+    return view.getUint32(0, true);
+  };
+
+  /**
+   * @param {number} ptr
+   */
+  const getI32 = function(ptr) {
+    return new Uint8Array(memory.buffer).slice(ptr, ptr + POINTER_WIDTH);
+  };
+
+  const outPointer = iterToI32(getI32(inPointer));
+  const length = iterToI32(getI32(inPointer + POINTER_WIDTH * 2));
+
+  return [outPointer, length];
+}
+
+/**
  * Create a slice of `[ptr, len]` from data (by allocating a buffer)
  *
  * @param {WebAssembly.Memory} memory
@@ -158,6 +187,7 @@ function getStr(memory, pointer, length) {
 module.exports = {
   POINTER_WIDTH,
   extractSlice,
+  extractVectorSlice,
   getStr,
   newF32Slice,
   newSlice,

--- a/tests/hello-example.js
+++ b/tests/hello-example.js
@@ -128,6 +128,19 @@ test(`slices and Vecs`, async (t) => {
     new Uint8Array([13, 37, 42, 42]));
 });
 
+test(`float vecs`, async (t) => {
+  const instance = await loadRust(`
+    ${allocFunction}
+    #[no_mangle]
+    pub extern "C" fn digest_floats(data: &[u8]) -> Vec<f32> {
+        vec![13., 37., 42., 42.]
+    }
+  `);
+  const digest = wrap(instance.exports, "digest_floats", ["&[u8]"], "Vec<f32>");
+  t.deepEqual(digest(new Uint8Array([0x00, 0x00, 0x00, 0x00])),
+    new Float32Array([13, 37, 42, 42]));
+});
+
 test(`str echo`, async (t) => {
   const instance = await loadRust(`
     ${allocFunction}

--- a/tests/hello-example.js
+++ b/tests/hello-example.js
@@ -128,6 +128,19 @@ test(`slices and Vecs`, async (t) => {
     new Uint8Array([13, 37, 42, 42]));
 });
 
+test(`u16 vecs`, async (t) => {
+  const instance = await loadRust(`
+    ${allocFunction}
+    #[no_mangle]
+    pub extern "C" fn digest_bytes(data: &[u8]) -> Vec<u16> {
+        vec![13, 37, 42, 65500]
+    }
+  `);
+  const digest = wrap(instance.exports, "digest_bytes", ["&[u8]"], "Vec<u16>");
+  t.deepEqual(digest(new Uint8Array([0x00, 0x00, 0x00, 0x00])),
+    new Uint16Array([13, 37, 42, 65500]));
+});
+
 test(`float vecs`, async (t) => {
   const instance = await loadRust(`
     ${allocFunction}

--- a/tests/hello-example.js
+++ b/tests/hello-example.js
@@ -133,12 +133,12 @@ test(`u16 vecs`, async (t) => {
     ${allocFunction}
     #[no_mangle]
     pub extern "C" fn digest_bytes(data: &[u8]) -> Vec<u16> {
-        vec![13, 37, 42, 65500]
+        vec![13, 37, 42, 65500, 15, 42, 64000]
     }
   `);
   const digest = wrap(instance.exports, "digest_bytes", ["&[u8]"], "Vec<u16>");
   t.deepEqual(digest(new Uint8Array([0x00, 0x00, 0x00, 0x00])),
-    new Uint16Array([13, 37, 42, 65500]));
+    new Uint16Array([13, 37, 42, 65500, 15, 42, 64000]));
 });
 
 test(`float vecs`, async (t) => {


### PR DESCRIPTION
This is something of a work-in-progress, but I wanted to get some feedback/early review. I needed support for both `Vec<f32>` and `Vec<u16>`, so I added them, along with [perhaps too] simple test cases. I also tried to simplify `getSliceData` by, well, removing it. Once I started doing multi-byte things, it seemed like it was adding an extra layer of indirection, when really what I wanted was a typed-array-window into memory at a specific point (`ptr`). Tests pass, so.... /shrug?